### PR TITLE
Provided access to video, audio, and subtitle stream sizes.

### DIFF
--- a/MediaInfo.Wrapper/Builder/LanguageMediaStreamBuilder.cs
+++ b/MediaInfo.Wrapper/Builder/LanguageMediaStreamBuilder.cs
@@ -36,6 +36,7 @@ namespace MediaInfo.Builder
       result.Default = Get<bool>("Default", TagBuilderHelper.TryGetBool);
       result.Forced = Get<bool>("Forced", TagBuilderHelper.TryGetBool);
       result.Lcid = LanguageHelper.GetLcidByShortName(language);
+      result.StreamSize = Get<long>("StreamSize", TagBuilderHelper.TryGetLong);
       return result;
     }
   }

--- a/MediaInfo.Wrapper/Model/LanguageMediaStream.cs
+++ b/MediaInfo.Wrapper/Model/LanguageMediaStream.cs
@@ -46,5 +46,13 @@ namespace MediaInfo.Model
     ///   <c>true</c> if forced; otherwise, <c>false</c>.
     /// </value>
     public bool Forced { get; set; }
+
+    /// <summary>
+    /// Gets the stream size.
+    /// </summary>
+    /// <value>
+    /// The stream size (bytes).
+    /// </value>
+    public long StreamSize { get; set; }
   }
 }


### PR DESCRIPTION
Added a `StreamSize` property to the `LanguageMediaStream` class to provide access to video, audio, and subtitle stream sizes.